### PR TITLE
ignore .pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+tools/esp_secure_cert_data/*


### PR DESCRIPTION
.pyc files are generated when executing python scripts in the  tools directory
