### PR TITLE
configure_esp_secure_cert.py: fix efuse_key_file argument configuration

### DIFF
--- a/tools/configure_esp_secure_cert.py
+++ b/tools/configure_esp_secure_cert.py
@@ -152,7 +152,7 @@ def main():
         help='eFuse key file which contains the '
              'key that shall be burned in '
              'the eFuse (e.g. HMAC key, ECDSA key)',
-        nargs=1, metavar='[/path/to/efuse key file]')
+        metavar='[/path/to/efuse key file]')
 
     parser.add_argument(
         '--port', '-p',


### PR DESCRIPTION
The call to `add_argument` that adds this option has `nargs=1` as an input parameter, which means that the field `efuse_key_file` of the `Namespace` object returned by `parse_args` will be a list.

This results in an error when `efuse_key_file` is passed to `os.path.exists()`, as this function does not expect a list.

Removing the `nargs=1` parameter from `add_argument` should fix this issue.