### PR TITLE
chore: bump deps, drop python 3.7 and support python 3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # Contains the pre-commit hooks for the repository
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
         exclude: '.+\.(md|rst)'
@@ -9,8 +9,8 @@ repos:
       - id: check-executables-have-shebangs
       - id: mixed-line-ending
         args: ['-f=lf']
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
     hooks:
       - id: flake8
         args: ['--config=.flake8', '--tee', '--benchmark']

--- a/tools/esp_secure_cert/configure_ds.py
+++ b/tools/esp_secure_cert/configure_ds.py
@@ -3,8 +3,9 @@ import hmac
 import os
 import struct
 import sys
+
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.asymmetric import rsa, ec
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.utils import int_to_bytes
 from esp_secure_cert.esp_secure_cert_helper import load_private_key

--- a/tools/esp_secure_cert/custflash_format.py
+++ b/tools/esp_secure_cert/custflash_format.py
@@ -1,9 +1,11 @@
-import sys
 import struct
 import zlib
-from esp_secure_cert.esp_secure_cert_helper import load_private_key, load_certificate
+
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.backends import default_backend
+from esp_secure_cert.esp_secure_cert_helper import (
+    load_certificate,
+    load_private_key,
+)
 
 # size is calculated as actual size + 16 (offset)
 ciphertext_size = {'esp32s2': 1600, 'esp32s3': 1600, 'esp32c3': 1216}

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,1 +1,1 @@
-cryptography==36.0.0
+cryptography

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -6,7 +6,7 @@ import sys
 
 
 def get_install_requires():
-    with open('requirements.txt') as f:
+    with open("requirements.txt") as f:
         required = f.read().splitlines()
         return required
 
@@ -53,17 +53,16 @@ setup(
     name="esp-secure-cert-tool",
     version=VERSION,
     description="A python utility which helps to configure and provision"
-                "the ESP platform with PKI credentials "
-                "into the esp_secure_cert partition",
+    "the ESP platform with PKI credentials "
+    "into the esp_secure_cert partition",
     long_description=long_description,
-    long_description_content_type='text/x-rst',
-    url="https://github.com/espressif/"
-        "esp_secure_cert_mgr/blob/main/tools",
+    long_description_content_type="text/x-rst",
+    url="https://github.com/espressif/" "esp_secure_cert_mgr/blob/main/tools",
     project_urls={
         "Documentation": "https://github.com/espressif/"
-                         "esp_secure_cert_mgr/blob/main/tools/README.md",
+        "esp_secure_cert_mgr/blob/main/tools/README.md",
         "Source": "https://github.com/espressif/esp_secure_cert_mgr/"
-                  "blob/main/tools/configure_esp_secure_cert.py",
+        "blob/main/tools/configure_esp_secure_cert.py",
     },
     author="Espressif Systems",
     author_email="",
@@ -76,12 +75,13 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS :: MacOS X",
         "Topic :: Software Development :: Embedded Systems",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     setup_requires=(["wheel"] if "bdist_wheel" in sys.argv else []),
     install_requires=get_install_requires(),
     include_package_data=True,


### PR DESCRIPTION
If installing with ESP-IDF, it is crucial to align ESP-IDF python dependencies at https://github.com/espressif/esp-idf/blob/master/tools/requirements/requirements.core.txt, to avoid downgrading.