### PR TITLE
Fix NameError: args.efuse_key_file -> efuse_key_file

### DIFF
--- a/tools/esp_secure_cert/configure_ds.py
+++ b/tools/esp_secure_cert/configure_ds.py
@@ -192,7 +192,7 @@ def configure_efuse_for_rsa(idf_target, port, hmac_key_file, efuse_key_file, rsa
         with open(efuse_key_file, "rb") as key_file:
             hmac_key = key_file.read()
 
-        print(f'Using the eFuse key given at {args.efuse_key_file}'
+        print(f'Using the eFuse key given at {efuse_key_file}'
                       'as the HMAC key')
 
     configure_efuse_key_block(idf_target, port, efuse_key_file, efuse_key_id, efuse_purpose)


### PR DESCRIPTION
Description
Fix NameError in configure_ds.py.
Replaces args.efuse_key_file with efuse_key_file in configure_efuse_for_rsa(), since args is not defined in that scope.

Related
Fixes crash reported when running configure_esp_secure_cert.py with --efuse_key_file.

Testing
Tested locally by running configure_esp_secure_cert.py with --keep_ds_data_on_host and --skip_flash options.
Confirmed no crash, correct output file generated.
