### PR TITLE
fix(esp_secure_cert): avoid double-free in free_ds_ctx for TLV format

### DIFF
--- a/srcs/esp_secure_cert_read.c
+++ b/srcs/esp_secure_cert_read.c
@@ -690,14 +690,25 @@ exit:
 
 void esp_secure_cert_free_ds_ctx(esp_ds_data_ctx_t *ds_ctx)
 {
-    esp_secure_cert_get_partition_format();
-    if (current_partition_format == ESP_SECURE_CERT_PF_TLV) {
-        esp_secure_cert_tlv_free_ds_ctx(ds_ctx);
+    if (ds_ctx == NULL) {
+        return;
     }
 
-    if (ds_ctx != NULL) {
-        free(ds_ctx->esp_ds_data);
+    esp_secure_cert_get_partition_format();
+    if (current_partition_format == ESP_SECURE_CERT_PF_TLV) {
+        /* For the TLV format esp_ds_data points directly into the
+         * memory-mapped esp_secure_cert partition and must not be
+         * passed to free(). esp_secure_cert_tlv_free_ds_ctx releases
+         * only the heap-allocated context wrapper.
+         */
+        esp_secure_cert_tlv_free_ds_ctx(ds_ctx);
+        return;
     }
+
+    /* Legacy (cust_flash / NVS) format paths heap-allocate esp_ds_data,
+     * so release both the inner buffer and the wrapper here.
+     */
+    free(ds_ctx->esp_ds_data);
     free(ds_ctx);
 }
 #endif


### PR DESCRIPTION
## Problem

`esp_secure_cert_free_ds_ctx` dispatched to `esp_secure_cert_tlv_free_ds_ctx` for the TLV format and then fell through into a shared cleanup block that dereferences and frees `ds_ctx` and `ds_ctx->esp_ds_data` again. On TLV partitions `esp_ds_data` also points directly into the memory-mapped flash region returned by `esp_secure_cert_tlv_get_addr`, so calling `free()` on it is not safe regardless of the wrapper double-free.

## Fix

Return immediately after the TLV-specific dispatch so the wrapper is released exactly once and the flash-resident `esp_ds_data` is never passed to `free()`. The legacy cust_flash and NVS cleanup path is preserved unchanged for partitions where `esp_ds_data` is heap allocated. A NULL guard up front keeps the function safe to call on partially initialised contexts.

## Compatibility

Behaviour unchanged for well-formed esp_secure_cert partitions on legacy formats. TLV-format callers no longer trigger the double-free during DS-backed teardown (e.g. Matter / RainMaker mutual-TLS shutdown).

## Test plan

- [ ] Builds against ESP-IDF v5.5 / v6.0
- [ ] `esp_secure_cert_app` example continues to bring up and tear down DS-backed esp-tls sessions on a TLV partition without heap corruption asserts
- [ ] Legacy cust_flash partition teardown remains unchanged

Internal reference: SCode Phase D PHD-SCM-07