### PR TITLE
fix(esp_secure_cert): don't free caller-owned buffer in ECDSA key path

### DIFF
--- a/srcs/esp_secure_cert_tlv_read.c
+++ b/srcs/esp_secure_cert_tlv_read.c
@@ -686,9 +686,11 @@ static esp_err_t esp_secure_cert_gen_ecdsa_key(esp_secure_cert_tlv_subtype_t sub
 
     err = esp_secure_cert_convert_key_to_der(key_buf, ESP_SECURE_CERT_DERIVED_ECDSA_KEY_SIZE, output_buf, ESP_SECURE_CERT_ECDSA_DER_KEY_SIZE);
     if (err != ESP_OK) {
-        free(key_buf);
-        free(output_buf);
         ESP_LOGE(TAG, "Failed to convert the plaintext key to DER format");
+        free(key_buf);
+        /* output_buf is owned by the caller (esp_secure_cert_tlv_get_addr);
+         * the caller releases it on error. Do not free it here.
+         */
         return ESP_FAIL;
     }
     // Free the plaintext private key as it is no longer needed


### PR DESCRIPTION
## Problem

`esp_secure_cert_gen_ecdsa_key` accepts an `output_buf` allocated and owned by its caller (`esp_secure_cert_tlv_get_addr`). When `esp_secure_cert_convert_key_to_der` failed, the helper released both `key_buf` and `output_buf` before returning. The caller's own error handler then released `output_buf` again, producing a double-free whenever DER conversion failed on an HMAC-derived ECDSA key.

## Fix

Drop the inner `free(output_buf)` so the caller alone is responsible for that buffer's lifetime. `key_buf`, which is owned by this helper, is still released on the error path.

## Compatibility

Behaviour unchanged for the success path and for well-formed esp_secure_cert partitions; only the error path is corrected. No public API change.

## Test plan

- [ ] Builds against ESP-IDF v5.5 / v6.0 on a target with `SOC_HMAC_SUPPORTED` (ESP32-S2/S3/C3/C6/H2)
- [ ] `esp_secure_cert_app` example still reads an HMAC-derived ECDSA key TLV correctly
- [ ] Forcing a DER conversion failure (e.g. invalid salt length) no longer corrupts heap

Internal reference: SCode Phase D PHD-SCM-06