### PR TITLE
fix(esp_secure_cert): reject encrypted TLVs shorter than GCM tag

### DIFF
--- a/srcs/esp_secure_cert_tlv_read.c
+++ b/srcs/esp_secure_cert_tlv_read.c
@@ -362,7 +362,20 @@ esp_err_t esp_secure_cert_tlv_get_addr(esp_secure_cert_tlv_type_t type, esp_secu
     if (ESP_SECURE_CERT_IS_TLV_ENCRYPTED(tlv_header->flags)) {
 #if SOC_HMAC_SUPPORTED
         ESP_LOGD(TAG, "TLV data is encrypted");
-        char *output_buf = (char *)heap_caps_calloc(1, sizeof(char) * (*len - HMAC_ENCRYPTION_TAG_LEN), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+        /* The encrypted payload stored in the TLV is laid out as
+         * ciphertext || GCM tag, so the stored length must be at least
+         * HMAC_ENCRYPTION_TAG_LEN bytes plus one byte of ciphertext.
+         * Anything below that indicates a malformed or truncated TLV;
+         * compute the ciphertext size in a safe order to avoid the
+         * uint32_t subtraction wrapping into a huge allocation request.
+         */
+        if (*len <= HMAC_ENCRYPTION_TAG_LEN) {
+            ESP_LOGE(TAG, "Encrypted TLV length %"PRIu32" is not larger than the GCM tag length %u",
+                     *len, (unsigned)HMAC_ENCRYPTION_TAG_LEN);
+            return ESP_ERR_INVALID_SIZE;
+        }
+        const uint32_t plaintext_len = *len - HMAC_ENCRYPTION_TAG_LEN;
+        char *output_buf = (char *)heap_caps_calloc(1, sizeof(char) * plaintext_len, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
         if (output_buf == NULL) {
             ESP_LOGE(TAG, "Failed to allocate memory");
             return ESP_ERR_NO_MEM;
@@ -376,7 +389,7 @@ esp_err_t esp_secure_cert_tlv_get_addr(esp_secure_cert_tlv_type_t type, esp_secu
         }
         ESP_FAULT_ASSERT(err == ESP_OK);
         *buffer = output_buf;
-        *len =  *len - HMAC_ENCRYPTION_TAG_LEN;
+        *len = plaintext_len;
 #else
         return ESP_ERR_NOT_SUPPORTED;
 #endif


### PR DESCRIPTION
## Problem

When an HMAC-encrypted TLV is read, `esp_secure_cert_tlv_get_addr` allocates the plaintext output buffer as `*len - HMAC_ENCRYPTION_TAG_LEN`, where `*len` is taken from the TLV header. If the stored length is below the 16-byte GCM tag length the unsigned subtraction wraps near `SIZE_MAX`, sending an implausibly large size to `heap_caps_calloc`. A stored length of exactly 16 produces a zero-byte allocation that the subsequent decrypt path will still treat as a valid output buffer.

## Fix

Validate the stored length before performing the subtraction. Encrypted TLVs are laid out as `ciphertext || tag`, so a length less than or equal to `HMAC_ENCRYPTION_TAG_LEN` cannot be well-formed. Return `ESP_ERR_INVALID_SIZE` in that case and otherwise size the allocation from a single sanitised local value reused when reporting the final plaintext length to the caller.

## Compatibility

Behaviour unchanged for well-formed encrypted TLVs (ciphertext plus 16-byte tag). Only malformed or truncated encrypted entries now fail cleanly instead of producing an undefined heap allocation.

## Test plan

- [ ] Builds against ESP-IDF v5.5 / v6.0 on a target with `SOC_HMAC_SUPPORTED`
- [ ] `esp_secure_cert_app` example still reads HMAC-encrypted TLVs from a normally provisioned partition
- [ ] Hand-crafted encrypted TLV with `length < 16` is rejected with `ESP_ERR_INVALID_SIZE` and no heap corruption

Internal reference: SCode Phase D PHD-SCM-05