### PR TITLE
fix(esp_secure_cert): check error before copying DS context from flash

### DIFF
--- a/srcs/esp_secure_cert_tlv_read.c
+++ b/srcs/esp_secure_cert_tlv_read.c
@@ -709,22 +709,34 @@ esp_ds_data_ctx_t *esp_secure_cert_tlv_get_ds_ctx(void)
         goto exit;
     }
 
-    uint32_t len;
+    uint32_t ds_data_len = 0;
     esp_ds_data_t *esp_ds_data;
-    esp_ret = esp_secure_cert_tlv_get_addr(ESP_SECURE_CERT_DS_DATA_TLV, ESP_SECURE_CERT_SUBTYPE_0, (void *) &esp_ds_data, &len);
+    esp_ret = esp_secure_cert_tlv_get_addr(ESP_SECURE_CERT_DS_DATA_TLV, ESP_SECURE_CERT_SUBTYPE_0, (void *) &esp_ds_data, &ds_data_len);
     if (esp_ret != ESP_OK) {
         ESP_LOGE(TAG, "Error in reading ds_data, returned %04X", esp_ret);
         goto exit;
     }
+    (void) ds_data_len; /* DS_DATA_TLV length is fixed by esp_ds_data_t layout */
 
+    uint32_t ds_ctx_len = 0;
     esp_ds_data_ctx_t *ds_data_ctx_flash;
-    esp_ret = esp_secure_cert_tlv_get_addr(ESP_SECURE_CERT_DS_CONTEXT_TLV, 0, (void *) &ds_data_ctx_flash, &len);
-    memcpy(ds_data_ctx, ds_data_ctx_flash, len);
-    ds_data_ctx->esp_ds_data = esp_ds_data;
+    esp_ret = esp_secure_cert_tlv_get_addr(ESP_SECURE_CERT_DS_CONTEXT_TLV, 0, (void *) &ds_data_ctx_flash, &ds_ctx_len);
     if (esp_ret != ESP_OK) {
         ESP_LOGE(TAG, "Error in reading ds_context, returned %04X", esp_ret);
         goto exit;
     }
+    /* Clamp the copy length to the size of the destination structure so
+     * that an oversized DS_CONTEXT_TLV cannot overflow the heap allocation,
+     * and reject a truncated TLV that cannot describe a full ds context.
+     */
+    if (ds_ctx_len < sizeof(esp_ds_data_ctx_t)) {
+        ESP_LOGE(TAG, "DS context TLV is shorter than esp_ds_data_ctx_t (%"PRIu32" < %u)",
+                 ds_ctx_len, (unsigned)sizeof(esp_ds_data_ctx_t));
+        esp_ret = ESP_ERR_INVALID_SIZE;
+        goto exit;
+    }
+    memcpy(ds_data_ctx, ds_data_ctx_flash, sizeof(esp_ds_data_ctx_t));
+    ds_data_ctx->esp_ds_data = esp_ds_data;
     return ds_data_ctx;
 exit:
     free(ds_data_ctx);


### PR DESCRIPTION
## Problem

`esp_secure_cert_tlv_get_ds_ctx` ran `memcpy(ds_data_ctx, ds_data_ctx_flash, len)` and assigned `ds_data_ctx->esp_ds_data` before checking the `esp_err_t` returned by the DS_CONTEXT_TLV lookup. The `len` variable was also reused across both `esp_secure_cert_tlv_get_addr` calls, so on a misprovisioned partition the copy would use the DS_DATA size (hundreds of bytes) into a small `esp_ds_data_ctx_t` heap allocation. Even on a clean error the memcpy could still execute against an uninitialised pointer.

## Fix

Move the error check ahead of the memcpy, use a dedicated length variable for each TLV lookup, and size the copy from `sizeof(esp_ds_data_ctx_t)` directly. Reject a DS_CONTEXT_TLV shorter than the destination structure with `ESP_ERR_INVALID_SIZE` so a truncated entry is not silently accepted.

## Compatibility

Behaviour unchanged for well-formed esp_secure_cert partitions: the destination layout already mandates a full `esp_ds_data_ctx_t` worth of data. Misprovisioned partitions now fail cleanly instead of corrupting the heap.

## Test plan

- [ ] Builds against ESP-IDF v5.5 / v6.0 on a DS-capable target (ESP32-S2/S3/C3/C6/H2)
- [ ] `esp_secure_cert_app` example still loads a TLV partition containing valid DS_DATA + DS_CONTEXT and brings up an esp-tls session
- [ ] Hand-crafted partition lacking DS_CONTEXT_TLV returns `NULL` from `esp_secure_cert_tlv_get_ds_ctx` without heap corruption

Internal reference: SCode Phase D PHD-SCM-08